### PR TITLE
chore: bump go version 1.22.2 --> 1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bank-vaults/vault-secrets-reloader
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/bank-vaults/vault-operator v1.22.1


### PR DESCRIPTION
## Overview

- This PR bumps the Go version from `1.22.2` to `1.22.3`.
- Reason: https://github.com/bank-vaults/vault-secrets-reloader/pull/206

```bash
go: sigs.k8s.io/e2e-framework@v0.4.0 requires go >= 1.22.3 (running go 1.22.2)
```
